### PR TITLE
Add sqlite-backed session store for session persistence

### DIFF
--- a/database/crud.go
+++ b/database/crud.go
@@ -9,11 +9,20 @@ import (
 	"zombiezen.com/go/sqlite/sqlitex"
 )
 
+func ExecuteInsertion(conn *sqlite.Conn, query string, namedParams map[string]interface{}) error {
+	return errors.Wrap(
+		sqlitex.Execute(conn, query, &sqlitex.ExecOptions{
+			Named: namedParams,
+		}),
+		"couldn't execute insertion statement",
+	)
+}
+
 //go:embed select-last-insert-rowid.sql
 var rawSelectLastInsertRowIDQuery string
 var selectLastInsertRowIDQuery string = strings.TrimSpace(rawSelectLastInsertRowIDQuery)
 
-func ExecuteInsertion(
+func ExecuteInsertionForID(
 	conn *sqlite.Conn, query string, namedParams map[string]interface{},
 ) (rowID int64, err error) {
 	defer sqlitex.Save(conn)(&err)

--- a/handling/time.go
+++ b/handling/time.go
@@ -1,0 +1,30 @@
+// Package handling provides utilities for handlers and background workers
+package handling
+
+import (
+	"context"
+	"time"
+)
+
+func Repeat(ctx context.Context, interval time.Duration, f func() (done bool, err error)) error {
+	ticker := time.NewTicker(interval)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := ctx.Err(); err != nil {
+				// Context was also canceled and it should have priority
+				return err
+			}
+
+			done, err := f()
+			if err != nil {
+				return err
+			}
+			if done {
+				return nil
+			}
+		}
+	}
+}

--- a/session/conf.go
+++ b/session/conf.go
@@ -52,7 +52,7 @@ func GetConfig() (c Config, err error) {
 	}
 
 	// TODO: when we implement idle timeout, pass that instead of absolute timeout
-	c.CookieOptions, err = getCookieOptions(c.Timeouts.Absolute)
+	c.CookieOptions, err = getCookieOptions()
 	if err != nil {
 		return Config{}, errors.Wrap(err, "couldn't make cookie options config")
 	}
@@ -69,7 +69,7 @@ func GetConfig() (c Config, err error) {
 }
 
 func getTimeouts() (t Timeouts, err error) {
-	const defaultAbsolute = 12 * 60 // default: 12 hours
+	const defaultAbsolute = 60 * 24 * 7 * 24 // default: 1 week
 	rawAbsolute, err := env.GetInt64(envPrefix+"TIMEOUTS_ABSOLUTE", defaultAbsolute)
 	if err != nil {
 		return Timeouts{}, errors.Wrap(err, "couldn't make absolute timeout config")
@@ -78,7 +78,7 @@ func getTimeouts() (t Timeouts, err error) {
 	return t, nil
 }
 
-func getCookieOptions(absoluteTimeout time.Duration) (o sessions.Options, err error) {
+func getCookieOptions() (o sessions.Options, err error) {
 	noHTTPSOnly, err := env.GetBool(envPrefix + "COOKIE_NOHTTPSONLY")
 	if err != nil {
 		return sessions.Options{}, errors.Wrap(err, "couldn't make HTTPS-only config")
@@ -87,7 +87,7 @@ func getCookieOptions(absoluteTimeout time.Duration) (o sessions.Options, err er
 	return sessions.Options{
 		Path:     "/",
 		Domain:   "",
-		MaxAge:   int(absoluteTimeout.Seconds()),
+		MaxAge:   0,
 		Secure:   !noHTTPSOnly,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,

--- a/session/conf.go
+++ b/session/conf.go
@@ -25,6 +25,7 @@ type CSRFOptions struct {
 
 type Config struct {
 	AuthKey       []byte
+	EncryptionKey []byte
 	Timeouts      Timeouts
 	CookieOptions sessions.Options
 	CookieName    string
@@ -32,10 +33,17 @@ type Config struct {
 }
 
 func GetConfig() (c Config, err error) {
+	// TODO: support key rotation
 	const authKeySize = 32
 	c.AuthKey, err = env.GetKey(envPrefix+"AUTH_KEY", authKeySize)
 	if err != nil {
-		return Config{}, errors.Wrap(err, "couldn't make session key config")
+		return Config{}, errors.Wrap(err, "couldn't make session auth key config")
+	}
+
+	const encryptionKeySize = 32
+	c.EncryptionKey, err = env.GetKey(envPrefix+"ENCRYPTION_KEY", encryptionKeySize)
+	if err != nil {
+		return Config{}, errors.Wrap(err, "couldn't make session encryption key config")
 	}
 
 	c.Timeouts, err = getTimeouts()

--- a/session/csrf.go
+++ b/session/csrf.go
@@ -23,7 +23,9 @@ func NewCSRFMiddleware(config Config, opts ...csrf.Option) func(http.Handler) ht
 	options := []csrf.Option{
 		csrf.Path(config.CookieOptions.Path),
 		csrf.Domain(config.CookieOptions.Domain),
-		csrf.MaxAge(config.CookieOptions.MaxAge),
+		// Don't set MaxAge, so that we can make the csrf cookie expire on browser close. This way, the
+		// browser doesn't write the csrf cookie to disk, and the user should never experience a CSRF
+		// error from the CSRF cookie timing out if they leave the tab open for a long time.
 		csrf.Secure(config.CookieOptions.Secure),
 		csrf.HttpOnly(config.CookieOptions.HttpOnly),
 		csrf.SameSite(sameSite),

--- a/session/memstore/store.go
+++ b/session/memstore/store.go
@@ -1,0 +1,20 @@
+// Package memstore provides an in-RAM (non-persistent) session store
+package memstore
+
+import (
+	"github.com/quasoft/memstore"
+
+	"github.com/sargassum-world/godest/session"
+)
+
+func NewStore(c session.Config) (store *session.Store, backingStore *memstore.MemStore) {
+	backingStore = memstore.NewMemStore(c.AuthKey, c.EncryptionKey)
+	backingStore.Options = &c.CookieOptions
+	backingStore.MaxAge(backingStore.Options.MaxAge)
+
+	return &session.Store{
+		Config:       c,
+		BackingStore: backingStore,
+		Codecs:       backingStore.Codecs,
+	}, backingStore
+}

--- a/session/sqlitestore/embeds.go
+++ b/session/sqlitestore/embeds.go
@@ -1,0 +1,28 @@
+package sqlitestore
+
+import (
+	"embed"
+	"io/fs"
+
+	"github.com/sargassum-world/godest/database"
+)
+
+// Migrations
+
+var (
+	//go:embed migrations/*
+	migrationsEFS   embed.FS
+	migrationsFS, _ = fs.Sub(migrationsEFS, "migrations")
+)
+
+var MigrationFiles []string = []string{
+	"1-initialize-schema-v0.3.0",
+}
+
+// Embeds
+
+func NewDomainEmbeds() database.DomainEmbeds {
+	return database.DomainEmbeds{
+		MigrationsFS: migrationsFS,
+	}
+}

--- a/session/sqlitestore/migrations/1-initialize-schema-v0.3.0.down.sql
+++ b/session/sqlitestore/migrations/1-initialize-schema-v0.3.0.down.sql
@@ -1,0 +1,2 @@
+drop table sessions_session;
+drop index sessions_session_idx_id;

--- a/session/sqlitestore/migrations/1-initialize-schema-v0.3.0.up.sql
+++ b/session/sqlitestore/migrations/1-initialize-schema-v0.3.0.up.sql
@@ -1,0 +1,12 @@
+-- Session
+
+create table sessions_session (
+  id                text    primary key,
+  data              text    not null,
+  creation_time     integer not null,
+  modification_time integer not null,
+  expiration_time   integer not null
+) strict;
+
+create index sessions_session_idx_id
+on sessions_session (id);

--- a/session/sqlitestore/models.go
+++ b/session/sqlitestore/models.go
@@ -1,0 +1,92 @@
+package sqlitestore
+
+import (
+	"time"
+
+	"zombiezen.com/go/sqlite"
+)
+
+// Session
+
+type Session struct {
+	ID               string
+	Data             string // Data is expected to be a base64-encoded string
+	CreationTime     time.Time
+	ModificationTime time.Time
+	ExpirationTime   time.Time
+}
+
+func (s Session) newInsertion() map[string]interface{} {
+	return map[string]interface{}{
+		"$id":                s.ID,
+		"$data":              s.Data,
+		"$creation_time":     s.CreationTime.UnixMilli(),
+		"$modification_time": s.ModificationTime.UnixMilli(),
+		"$expiration_time":   s.ExpirationTime.UnixMilli(),
+	}
+}
+
+func (s Session) newUpdate() map[string]interface{} {
+	return map[string]interface{}{
+		"$id":                s.ID,
+		"$data":              s.Data,
+		"$modification_time": s.ModificationTime.UnixMilli(),
+	}
+}
+
+func (s Session) newDelete() map[string]interface{} {
+	return map[string]interface{}{
+		"$id": s.ID,
+	}
+}
+
+func (s Session) newDeletePastExpiration() map[string]interface{} {
+	return map[string]interface{}{
+		"$expiration_time_threshold": s.ExpirationTime.UnixMilli(),
+	}
+}
+
+func newSessionSelection(id string) map[string]interface{} {
+	return map[string]interface{}{
+		"$id": id,
+	}
+}
+
+// Sessions
+
+type sessionsSelector struct {
+	ids      []string
+	sessions map[string]Session
+}
+
+func newSessionsSelector() *sessionsSelector {
+	return &sessionsSelector{
+		ids:      make([]string, 0),
+		sessions: make(map[string]Session),
+	}
+}
+
+func (sel *sessionsSelector) Step(s *sqlite.Stmt) error {
+	id := s.GetText("id")
+	if _, ok := sel.sessions[id]; !ok {
+		sel.sessions[id] = Session{
+			ID:               s.GetText("id"),
+			Data:             s.GetText("data"),
+			CreationTime:     time.UnixMilli(s.GetInt64("creation_time")),
+			ModificationTime: time.UnixMilli(s.GetInt64("modification_time")),
+			ExpirationTime:   time.UnixMilli(s.GetInt64("expiration_time")),
+		}
+		if id != "" {
+			sel.ids = append(sel.ids, id)
+		}
+	}
+	return nil
+}
+
+func (sel *sessionsSelector) Sessions() []Session {
+	sessions := make([]Session, len(sel.ids))
+	for i, id := range sel.ids {
+		sessions[i] = sel.sessions[id]
+	}
+	return sessions
+}

--- a/session/sqlitestore/queries/delete-session.sql
+++ b/session/sqlitestore/queries/delete-session.sql
@@ -1,0 +1,2 @@
+delete from sessions_session
+where sessions_session.id = $id

--- a/session/sqlitestore/queries/delete-sessions-past-expiration.sql
+++ b/session/sqlitestore/queries/delete-sessions-past-expiration.sql
@@ -1,0 +1,2 @@
+delete from sessions_session
+where sessions_session.expiration_time < $expiration_time_threshold

--- a/session/sqlitestore/queries/insert-session.sql
+++ b/session/sqlitestore/queries/insert-session.sql
@@ -1,0 +1,2 @@
+insert into sessions_session (id, data, creation_time, modification_time, expiration_time)
+values ($id, $data, $creation_time, $modification_time, $expiration_time);

--- a/session/sqlitestore/queries/select-session.sql
+++ b/session/sqlitestore/queries/select-session.sql
@@ -1,0 +1,9 @@
+select
+  s.id                as id,
+  s.data              as data,
+  s.creation_time     as creation_time,
+  s.modification_time as modification_time,
+  s.expiration_time   as expiration_time
+from sessions_session as s
+where
+  s.id = $id

--- a/session/sqlitestore/queries/update-session.sql
+++ b/session/sqlitestore/queries/update-session.sql
@@ -1,0 +1,5 @@
+update sessions_session
+set
+  data = $data,
+  modification_time = $modification_time
+where sessions_session.id = $id

--- a/session/sqlitestore/store.go
+++ b/session/sqlitestore/store.go
@@ -1,0 +1,283 @@
+// Package sqlitestore store provides a sqlite-backed session store using [database.DB]
+package sqlitestore
+
+import (
+	"context"
+	_ "embed"
+	"encoding/base32"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+	"github.com/pkg/errors"
+
+	"github.com/sargassum-world/godest/database"
+	"github.com/sargassum-world/godest/handling"
+	"github.com/sargassum-world/godest/session"
+)
+
+// SqliteStore stores sessions in a godest sqlite-backed [database.DB].
+type SqliteStore struct {
+	Codecs          []securecookie.Codec
+	Options         *sessions.Options
+	AbsoluteTimeout time.Duration
+	db              *database.DB
+}
+
+// NewSqliteStore returns a new SqliteStore.
+//
+// The db argument should be a [database.DB] with a "sessions_session" table already initialized
+// according to the schema defined by the migrations in [NewDomainEmbeds].
+//
+// See [sessions.NewCookieStore] for a description of the other parameters.
+func NewSqliteStore(db *database.DB, keyPairs ...[]byte) *SqliteStore {
+	// TODO: also take a parameter for a function to modify a Session with *sssion.Session.Valuesa,
+	// which would enable e.g. storing the user identity in a column rather than an encoded string,
+	// to enable selecting all sessions fo a user
+	// We don't allow specifying the table name programatically (which would require turning our
+	// embedded migrations and queries into Go templates to render into sql), because renaming the
+	// table would require its own dedicated migration, and it's too much complexity to deal with that
+	// use case.
+	const maxAge = 86400 * 30
+	store := &SqliteStore{
+		Codecs: securecookie.CodecsFromPairs(keyPairs...),
+		Options: &sessions.Options{
+			Path:   "/",
+			MaxAge: maxAge,
+		},
+		db: db,
+	}
+
+	store.MaxAge(store.Options.MaxAge)
+	return store
+}
+
+// MaxLength restricts the maximum length of new sessions to l.
+// If l is 0 there is no limit to the size of a sesson, use with caution.
+// The default for a new SqliteStore is 4096 (default for securecookie).
+func (ss *SqliteStore) MaxLength(l int) {
+	for _, c := range ss.Codecs {
+		if codec, ok := c.(*securecookie.SecureCookie); ok {
+			codec.MaxLength(l)
+		}
+	}
+}
+
+// MaxAge sets the maximum age for the store and the underlying cookie implementation. Individual
+// sessions can be deleted by setting [session.Options.MaxAge] = -1 for that session.
+func (ss *SqliteStore) MaxAge(age int) {
+	ss.Options.MaxAge = age
+
+	// Set the maxAge for each securecookie instance
+	for _, codec := range ss.Codecs {
+		if sc, ok := codec.(*securecookie.SecureCookie); ok {
+			sc.MaxAge(age)
+		}
+	}
+}
+
+// Get returns a session for the given name after adding it to the registry.
+//
+// See [sessions.CookieStore.Get].
+func (ss *SqliteStore) Get(r *http.Request, name string) (*sessions.Session, error) {
+	return sessions.GetRegistry(r).Get(ss, name)
+}
+
+// New creates and returns a session for the given name without adding it to the registry.
+//
+// See [sessions.CookieStore.New].
+func (ss *SqliteStore) New(r *http.Request, name string) (*sessions.Session, error) {
+	s := sessions.NewSession(ss, name)
+	options := *ss.Options
+	s.Options = &options
+	s.IsNew = true
+	cookie, err := r.Cookie(name)
+	if err != nil {
+		// Cookie not found, so this is a new session
+		return s, nil
+	}
+	if err = securecookie.DecodeMulti(name, cookie.Value, &s.ID, ss.Codecs...); err != nil {
+		// Treat invalid cookie as a new session
+		return s, errors.Wrapf(err, "couldn't decode cookie value %s into session id", cookie.Value)
+	}
+
+	sess, err := ss.GetSession(r.Context(), s.ID)
+	if err != nil {
+		// No value found in database, so treat this as a new session
+		return s, nil
+	}
+	if time.Until(sess.ExpirationTime) < 0 {
+		return s, errors.Errorf(
+			"Session expired on %s, but it is %s now", sess.ExpirationTime, time.Now(),
+		)
+	}
+
+	if err := securecookie.DecodeMulti(s.Name(), sess.Data, &s.Values, ss.Codecs...); err != nil {
+		// Database value couldn't be decoded into session values, so treat this as a new session
+		return s, nil
+	}
+	s.IsNew = false
+	return s, nil
+}
+
+var base32Encoding = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// Save adds a single session to the response.
+//
+// If the Options.MaxAge of the session is <= 0 then the session record will be deleted from the
+// database. With this process it properly enforces session cookie handling, so no need to trust
+// the web browser's cookie management.
+func (ss *SqliteStore) Save(r *http.Request, w http.ResponseWriter, s *sessions.Session) error {
+	// TODO: log all errors in this function, because they don't get bubbled up for some reason!
+	// When we exit early with an error, the server may return a 0b respose with 200
+	// FIXME: or is there something wrong with how we're using github.com/gorilla/sessions that is
+	// suppressing the errors?
+	// Delete if max-age is < 0
+	if s.Options.MaxAge < 0 {
+		if err := ss.DeleteSession(r.Context(), s.ID); err != nil {
+			return errors.Wrap(err, "couldn't delete session with max-age <= 0")
+		}
+		http.SetCookie(w, sessions.NewCookie(s.Name(), "", s.Options))
+		return nil
+	}
+
+	if s.ID == "" || s.IsNew {
+		const idSize = 32
+		s.ID = base32Encoding.EncodeToString(securecookie.GenerateRandomKey(idSize))
+		sess, err := ss.createdSession(s)
+		if err != nil {
+			return errors.Wrap(err, "couldn't convert cookie session into record to insert into db")
+		}
+		if err = ss.AddSession(r.Context(), sess); err != nil {
+			return err
+		}
+	} else {
+		sess, err := ss.modifiedSession(s)
+		if err != nil {
+			return errors.Wrap(err, "couldn't convert cookie session into record to update in db")
+		}
+		if err := ss.UpdateSession(r.Context(), sess); err != nil {
+			return err
+		}
+	}
+
+	encoded, err := securecookie.EncodeMulti(s.Name(), s.ID, ss.Codecs...)
+	if err != nil {
+		return errors.Wrap(err, "couldn't encode session id for cookie")
+	}
+	http.SetCookie(w, sessions.NewCookie(s.Name(), encoded, s.Options))
+	return nil
+}
+
+func (ss *SqliteStore) createdSession(s *sessions.Session) (sess Session, err error) {
+	sess.ID = s.ID
+	sess.Data, err = securecookie.EncodeMulti(s.Name(), s.Values, ss.Codecs...)
+	if err != nil {
+		return Session{}, errors.Wrap(err, "couldn't encode session values")
+	}
+	sess.CreationTime = time.Now()
+	sess.ModificationTime = sess.CreationTime
+	sess.ExpirationTime = sess.CreationTime.Add(ss.AbsoluteTimeout)
+	return sess, nil
+}
+
+func (ss *SqliteStore) modifiedSession(s *sessions.Session) (sess Session, err error) {
+	sess.ID = s.ID
+	sess.Data, err = securecookie.EncodeMulti(s.Name(), s.Values, ss.Codecs...)
+	if err != nil {
+		return Session{}, errors.Wrap(err, "couldn't encode session values")
+	}
+	sess.ModificationTime = time.Now()
+	return sess, nil
+}
+
+//go:embed queries/insert-session.sql
+var rawInsertSessionQuery string
+var insertSessionQuery string = strings.TrimSpace(rawInsertSessionQuery)
+
+func (ss *SqliteStore) AddSession(ctx context.Context, sess Session) (err error) {
+	err = ss.db.ExecuteInsertion(ctx, insertSessionQuery, sess.newInsertion())
+	if err != nil {
+		return errors.Wrapf(err, "couldn't add session")
+	}
+	return nil
+}
+
+//go:embed queries/update-session.sql
+var rawUpdateSessionQuery string
+var updateSessionQuery string = strings.TrimSpace(rawUpdateSessionQuery)
+
+func (ss *SqliteStore) UpdateSession(ctx context.Context, sess Session) (err error) {
+	return errors.Wrapf(
+		ss.db.ExecuteUpdate(ctx, updateSessionQuery, sess.newUpdate()),
+		"couldn't update session with id %s", sess.ID,
+	)
+}
+
+//go:embed queries/delete-session.sql
+var rawDeleteSessionQuery string
+var deleteSessionQuery string = strings.TrimSpace(rawDeleteSessionQuery)
+
+func (ss *SqliteStore) DeleteSession(ctx context.Context, id string) (err error) {
+	return errors.Wrapf(
+		ss.db.ExecuteDelete(ctx, deleteSessionQuery, Session{ID: id}.newDelete()),
+		"couldn't delete session with id %s", id,
+	)
+}
+
+//go:embed queries/delete-sessions-past-expiration.sql
+var rawDeleteExpiredSessionsQuery string
+var deleteExpiredSessionsQuery string = strings.TrimSpace(rawDeleteExpiredSessionsQuery)
+
+func (ss *SqliteStore) DeleteExpiredSessions(ctx context.Context, threshold time.Time) (err error) {
+	return errors.Wrapf(
+		ss.db.ExecuteDelete(
+			ctx, deleteExpiredSessionsQuery, Session{ExpirationTime: threshold}.newDeletePastExpiration(),
+		),
+		"couldn't delete sessions which expired before %s", threshold,
+	)
+}
+
+func (ss *SqliteStore) PeriodicallyCleanup(
+	ctx context.Context, interval time.Duration,
+) error {
+	return handling.Repeat(ctx, interval, func() (done bool, err error) {
+		return false, errors.Wrap(
+			ss.DeleteExpiredSessions(ctx, time.Now()),
+			"couldn't perform periodic deletion of expired sessions",
+		)
+	})
+}
+
+//go:embed queries/select-session.sql
+var rawSelectSessionQuery string
+var selectSessionQuery string = strings.TrimSpace(rawSelectSessionQuery)
+
+func (ss *SqliteStore) GetSession(ctx context.Context, id string) (sess Session, err error) {
+	sel := newSessionsSelector()
+	if err = ss.db.ExecuteSelection(
+		ctx, selectSessionQuery, newSessionSelection(id), sel.Step,
+	); err != nil {
+		return Session{}, errors.Wrapf(err, "couldn't get session with id %s", id)
+	}
+	sessions := sel.Sessions()
+	if len(sessions) == 0 {
+		return Session{}, errors.Errorf("couldn't get non-existent session with id %s", id)
+	}
+	return sessions[0], nil
+}
+
+func NewStore(db *database.DB, c session.Config) (store *session.Store, backingStore *SqliteStore) {
+	backingStore = NewSqliteStore(db, c.AuthKey, c.EncryptionKey)
+	backingStore.AbsoluteTimeout = c.Timeouts.Absolute
+	backingStore.Options = &c.CookieOptions
+	backingStore.MaxAge(backingStore.Options.MaxAge)
+
+	return &session.Store{
+		Config:       c,
+		BackingStore: backingStore,
+		Codecs:       backingStore.Codecs,
+	}, backingStore
+}

--- a/session/sqlitestore/store.go
+++ b/session/sqlitestore/store.go
@@ -32,7 +32,9 @@ type SqliteStore struct {
 // according to the schema defined by the migrations in [NewDomainEmbeds].
 //
 // See [sessions.NewCookieStore] for a description of the other parameters.
-func NewSqliteStore(db *database.DB, keyPairs ...[]byte) *SqliteStore {
+func NewSqliteStore(
+	db *database.DB, absoluteTimeout time.Duration, keyPairs ...[]byte,
+) *SqliteStore {
 	// TODO: also take a parameter for a function to modify a Session with *sssion.Session.Valuesa,
 	// which would enable e.g. storing the user identity in a column rather than an encoded string,
 	// to enable selecting all sessions fo a user
@@ -47,7 +49,8 @@ func NewSqliteStore(db *database.DB, keyPairs ...[]byte) *SqliteStore {
 			Path:   "/",
 			MaxAge: maxAge,
 		},
-		db: db,
+		AbsoluteTimeout: absoluteTimeout,
+		db:              db,
 	}
 
 	store.MaxAge(store.Options.MaxAge)
@@ -270,8 +273,7 @@ func (ss *SqliteStore) GetSession(ctx context.Context, id string) (sess Session,
 }
 
 func NewStore(db *database.DB, c session.Config) (store *session.Store, backingStore *SqliteStore) {
-	backingStore = NewSqliteStore(db, c.AuthKey, c.EncryptionKey)
-	backingStore.AbsoluteTimeout = c.Timeouts.Absolute
+	backingStore = NewSqliteStore(db, c.Timeouts.Absolute, c.AuthKey, c.EncryptionKey)
 	backingStore.Options = &c.CookieOptions
 	backingStore.MaxAge(backingStore.Options.MaxAge)
 

--- a/session/store.go
+++ b/session/store.go
@@ -8,62 +8,42 @@ import (
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	"github.com/pkg/errors"
-	"github.com/quasoft/memstore"
 )
 
-type Store interface {
-	CSRFOptions() CSRFOptions
-	New(r *http.Request) (*sessions.Session, error)
-	Get(r *http.Request) (*sessions.Session, error)
-	Lookup(id string) (*sessions.Session, error)
-	NewCSRFMiddleware(opts ...csrf.Option) func(http.Handler) http.Handler
+type Store struct {
+	Config       Config
+	BackingStore sessions.Store
+	Codecs       []securecookie.Codec
 }
 
-// MemStore
-
-type MemStore struct {
-	Config Config
-	Store  *memstore.MemStore
-}
-
-func NewMemStore(c Config) *MemStore {
-	store := memstore.NewMemStore(c.AuthKey)
-	store.Options = &c.CookieOptions
-
-	return &MemStore{
-		Config: c,
-		Store:  store,
-	}
-}
-
-func (ss *MemStore) CSRFOptions() CSRFOptions {
+func (ss *Store) CSRFOptions() CSRFOptions {
 	return ss.Config.CSRFOptions
 }
 
-func (ss *MemStore) New(r *http.Request) (*sessions.Session, error) {
-	sess, err := ss.Store.New(r, ss.Config.CookieName)
+func (ss *Store) New(r *http.Request) (*sessions.Session, error) {
+	sess, err := ss.BackingStore.New(r, ss.Config.CookieName)
 	return sess, errors.Wrap(err, "couldn't make session")
 }
 
-func (ss *MemStore) Get(r *http.Request) (*sessions.Session, error) {
-	sess, err := ss.Store.Get(r, ss.Config.CookieName)
+func (ss *Store) Get(r *http.Request) (*sessions.Session, error) {
+	sess, err := ss.BackingStore.Get(r, ss.Config.CookieName)
 	return sess, errors.Wrap(err, "couldn't get session from request")
 }
 
-func (ss *MemStore) Lookup(id string) (*sessions.Session, error) {
+func (ss *Store) Lookup(id string) (*sessions.Session, error) {
 	r, err := http.NewRequestWithContext(context.Background(), "GET", "/", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't generate HTTP request to get session")
 	}
-	encrypted, err := securecookie.EncodeMulti(ss.Config.CookieName, id, ss.Store.Codecs...)
+	encrypted, err := securecookie.EncodeMulti(ss.Config.CookieName, id, ss.Codecs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't generate encoded HTTP cookie to get session")
 	}
 	r.AddCookie(sessions.NewCookie(ss.Config.CookieName, encrypted, &ss.Config.CookieOptions))
-	sess, err := ss.Store.Get(r, ss.Config.CookieName)
+	sess, err := ss.BackingStore.Get(r, ss.Config.CookieName)
 	return sess, errors.Wrap(err, "couldn't get session without request")
 }
 
-func (ss *MemStore) NewCSRFMiddleware(opts ...csrf.Option) func(http.Handler) http.Handler {
+func (ss *Store) NewCSRFMiddleware(opts ...csrf.Option) func(http.Handler) http.Handler {
 	return NewCSRFMiddleware(ss.Config, opts...)
 }


### PR DESCRIPTION
This PR adds a SQLite-backed store (more specifically, a store backed by [zombiezen/go-sqlite](https://github.com/zombiezen/go-sqlite) by way of godest's `database.DB` type) for [gorilla/sessions](https://github.com/gorilla/sessions). The store comes with embedded schema migrations and queries. It tracks the creation, modification, and expiration times of sessions (with inspiration from [michaeljs1990/sqlitestore](https://github.com/michaeljs1990/sqlitestore)), where expiration time is set by an "absolute timeout" parameter when instantiating the store (which is decoupled from the max-age parameter for cookies, allowing cookies to omit the max-age parameter for security reasons), and it provides a background worker function to periodically delete expired sessions from the database.

Additionally, this PR makes several breaking changes:
- The `session.Store` type is changed from an interface to a struct for simplicity (which means that anything which took `session.Store` as a parameter should now take pointers to `session.Store`).
- The `database.ExecuteInsertion` function and `database.DB.ExecuteInsertion` method are now renamed to `ExecuteInsertionForID`, and a new `database.ExecuteInsertion` function and `database.DB.ExecuteInsertion` method are created which don't perform a database query to return the ID of the row added by the insertion.
- All stores, including the `MemStore`-backed type, now use an environment-variable-defined session encryption key. This is required for session data to be decodable between application restarts, for some reason (perhaps related to how [gorilla/securecookie](https://github.com/gorilla/securecookie/) behaves?).
- The `max-age` parameter of cookies is now always set to 0, following [OWASP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#expire-and-max-age-attributes) for session management. To summarize, setting `max-age=0` prevents the browser from storing cookies on disk, and forces the session to disappear when the web browser is closed. Additionally, setting `max-age=0` for the CSRF cookies should ensure that a user will not encounter an invalid-CSRF error merely from leaving a tab open long enough for the CSRF cookie to expire and then submitting a form afterwards. However, we will want to add a "remember me" feature to the login page in the future. For now, we rely on the SQLite-backed session store to enforce an absolute timeout on all sessions (defaulting to one week), ignoring cookies' max-age parameters.

Additionally, this PR adds some functionality:
- A `handling` subpackage is added with code migrated from [sargassum-world/fluitans](https://github.com/sargassum-world/fluitans)/internal/app/pslive/handling for a context-cancellable way to run a function at regular intervals - since this is useful for making background workers across projects, including a background worker provided by this PR's SQLite-backed session store