### PR TITLE
Support URL-style query params in topic-based routing with the pubsub Broker

### DIFF
--- a/handling/channels.go
+++ b/handling/channels.go
@@ -4,6 +4,8 @@ import (
 	"context"
 )
 
+type Consumer[T any] func(elem T) (done bool, err error)
+
 func Consume[T any](
 	ctx context.Context, ch <-chan T, f func(elem T) (done bool, err error),
 ) error {

--- a/handling/channels.go
+++ b/handling/channels.go
@@ -6,9 +6,7 @@ import (
 
 type Consumer[T any] func(elem T) (done bool, err error)
 
-func Consume[T any](
-	ctx context.Context, ch <-chan T, f func(elem T) (done bool, err error),
-) error {
+func Consume[T any](ctx context.Context, ch <-chan T, f Consumer[T]) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/handling/errors.go
+++ b/handling/errors.go
@@ -1,0 +1,14 @@
+package handling
+
+import (
+	"github.com/pkg/errors"
+)
+
+func Except(err error, exceptions ...error) error {
+	for _, exception := range exceptions {
+		if errors.Is(err, exception) {
+			return nil
+		}
+	}
+	return err
+}

--- a/handling/time.go
+++ b/handling/time.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+type Worker func() (done bool, err error)
+
 func Repeat(ctx context.Context, interval time.Duration, f func() (done bool, err error)) error {
 	if interval == 0 {
 		return repeatInstantly(ctx, f)

--- a/handling/time.go
+++ b/handling/time.go
@@ -8,7 +8,7 @@ import (
 
 type Worker func() (done bool, err error)
 
-func Repeat(ctx context.Context, interval time.Duration, f func() (done bool, err error)) error {
+func Repeat(ctx context.Context, interval time.Duration, f Worker) error {
 	if interval == 0 {
 		return repeatInstantly(ctx, f)
 	}
@@ -35,7 +35,7 @@ func Repeat(ctx context.Context, interval time.Duration, f func() (done bool, er
 	}
 }
 
-func repeatInstantly(ctx context.Context, f func() (done bool, err error)) error {
+func repeatInstantly(ctx context.Context, f Worker) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/handling/time.go
+++ b/handling/time.go
@@ -7,12 +7,38 @@ import (
 )
 
 func Repeat(ctx context.Context, interval time.Duration, f func() (done bool, err error)) error {
+	if interval == 0 {
+		return repeatInstantly(ctx, f)
+	}
 	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
+			if err := ctx.Err(); err != nil {
+				// Context was also canceled and it should have priority
+				return err
+			}
+
+			done, err := f()
+			if err != nil {
+				return err
+			}
+			if done {
+				return nil
+			}
+		}
+	}
+}
+
+func repeatInstantly(ctx context.Context, f func() (done bool, err error)) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
 			if err := ctx.Err(); err != nil {
 				// Context was also canceled and it should have priority
 				return err


### PR DESCRIPTION
This PR changes `pubsub.Broker`'s routing behavior so that topics which can be parsed as request URIs for routing are routed as the URI path only, excluding the query params. Previously, routing of a topic like "/video-streams/external.mjpeg?url=localhost:8000" would've searched for a handler registered on "/video-streams/external.mjpeg?url=localhost:8000"; now, it instead searches for a handler registered on "/video-streams/external.mjpeg", and the `pubsub.BrokerContext` has a new `Query()` method to try to parse the URI query params from the full topic (so that we could get "localhost:8000" from checking the query param "url").

This PR also:
- Makes `handling.Repeat` work with a value of 0 for parameter `interval`.
- Adds a `handling.Except` function to discard an `error` value if it matches any provided errors. This improves the concision/readability of error-handling code where certain errors (e.g. in handlers which return errors) should be suppressed instead of being bubbled up.